### PR TITLE
fix: websocket test failed

### DIFF
--- a/bson/bson_test.go
+++ b/bson/bson_test.go
@@ -581,7 +581,7 @@ var marshalErrorItems = []testItemType{
 	{&structWithDupKeys{},
 		"Duplicated key 'name' in struct bson_test.structWithDupKeys"},
 	{bson.Raw{0x0A, []byte{}},
-		"Attempted to unmarshal Raw kind 10 as a document"},
+		"Attempted to marshal Raw kind 10 as a document"},
 	{&inlineCantPtr{&struct{ A, B int }{1, 2}},
 		"Option ,inline needs a struct value or map field"},
 	{&inlineDupName{1, struct{ A, B int }{2, 3}},
@@ -1429,9 +1429,9 @@ func (s *S) TestObjectIdJSONUnmarshaling(c *C) {
 func (s *S) TestObjectIdJSONUnmarshalingError(c *C) {
 	v := jsonType{}
 	err := json.Unmarshal([]byte(`{"Id":"4d88e15b60f486e428412dc9A"}`), &v)
-	c.Assert(err, ErrorMatches, `Invalid ObjectId in JSON: "4d88e15b60f486e428412dc9A"`)
+	c.Assert(err, ErrorMatches, `invalid ObjectId in JSON: "4d88e15b60f486e428412dc9A"`)
 	err = json.Unmarshal([]byte(`{"Id":"4d88e15b60f486e428412dcZ"}`), &v)
-	c.Assert(err, ErrorMatches, `Invalid ObjectId in JSON: "4d88e15b60f486e428412dcZ" .*`)
+	c.Assert(err, ErrorMatches, `invalid ObjectId in JSON: "4d88e15b60f486e428412dcZ" .*`)
 }
 
 // --------------------------------------------------------------------------

--- a/websocket/client_test.go
+++ b/websocket/client_test.go
@@ -1,9 +1,12 @@
 package websocket
 
 import (
+	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,57 +14,67 @@ import (
 )
 
 func TestWSClient(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
 	http.HandleFunc("/test/client", func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			fmt.Println("wg.Done")
+			wg.Done()
+		}()
+
 		conn, err := websocket.Upgrade(w, r, nil, 1024, 1024)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
+		log.Println("websocket.Upgrade")
+
+		conn.SetPingHandler(func(d string) error {
+			fmt.Println("receive from client: ", d)
+			conn.WriteMessage(websocket.PongMessage, []byte("server.Pong"))
+			return nil
+		})
 
 		msgType, msg, err := conn.ReadMessage()
-		conn.WriteMessage(websocket.TextMessage, msg)
-
 		if err != nil {
 			t.Fatal(err.Error())
 		}
-
 		if msgType != websocket.TextMessage {
 			t.Fatal("invalid msg type", msgType)
 		}
 
-		msgType, msg, err = conn.ReadMessage()
+		log.Println("server conn.ReadMessage")
+
+		err = conn.WriteMessage(websocket.TextMessage, msg)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
+		log.Println("server conn.WriteMessage")
 
-		if msgType != websocket.PingMessage {
-			t.Fatal("invalid msg type", msgType)
-		}
-
-		conn.WriteMessage(websocket.PongMessage, []byte{})
-
-		conn.WriteMessage(websocket.PingMessage, []byte{})
-
+		log.Println("server conn.ReadMessage")
 		msgType, msg, err = conn.ReadMessage()
+		log.Println("server conn.ReadMessage")
 		if err != nil {
+			log.Println(err)
 			t.Fatal(err.Error())
 		}
-		println(msgType)
-		if msgType != websocket.PongMessage {
-
+		if msgType != websocket.TextMessage {
 			t.Fatal("invalid msg type", msgType)
 		}
+		log.Println("server conn.ReadMessage")
+		conn.WriteMessage(websocket.PongMessage, []byte("server.Pong"))
 	})
 
-	go http.ListenAndServe(":65500", nil)
+	go http.ListenAndServe(":65501", nil)
 
 	time.Sleep(time.Second * 1)
 
-	conn, err := net.Dial("tcp", "127.0.0.1:65500")
+	conn, err := net.Dial("tcp", "127.0.0.1:65501")
 
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	ws, _, err := NewClient(conn, &url.URL{Host: "127.0.0.1:65500", Path: "/test/client"}, nil)
+	ws, _, err := NewClient(conn, &url.URL{Scheme: "ws", Host: "127.0.0.1:65501", Path: "/test/client"}, nil)
 
 	if err != nil {
 		t.Fatal(err.Error())
@@ -72,9 +85,12 @@ func TestWSClient(t *testing.T) {
 		payload[i] = 'x'
 	}
 
-	ws.WriteString(payload)
+	err = ws.WriteString(payload)
+	if err != nil {
+		fmt.Println(err)
+	}
 
-	msgType, msg, err := ws.Read()
+	msgType, msg, err := ws.ReadMessage()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -84,12 +100,17 @@ func TestWSClient(t *testing.T) {
 
 	if string(msg) != string(payload) {
 		t.Fatal("invalid msg", string(msg))
-
 	}
 
 	//test ping
-	ws.Ping([]byte{})
+	err = ws.Ping([]byte("client.Ping"))
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Println("ws.ReadMessage: PongMessage")
 	msgType, msg, err = ws.ReadMessage()
+	fmt.Println("ws.ReadMessage: PongMessage")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -97,4 +118,11 @@ func TestWSClient(t *testing.T) {
 		t.Fatal("invalid msg type", msgType)
 	}
 
+	fmt.Println(string(msg))
+
+	ws.WriteMessage(websocket.TextMessage, []byte("done"))
+
+	// ws.Close()
+	wg.Wait()
+	log.Println("end")
 }

--- a/websocket/server_test.go
+++ b/websocket/server_test.go
@@ -63,7 +63,7 @@ func TestWSServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	ws, _, err := websocket.NewClient(conn, &url.URL{Host: "127.0.0.1:65500", Path: "/test/server"}, nil, 1024, 1024)
+	ws, _, err := websocket.NewClient(conn, &url.URL{Scheme: "ws", Host: "127.0.0.1:65500", Path: "/test/server"}, nil, 1024, 1024)
 
 	ws.SetPongHandler(func(string) error {
 		println("pong")


### PR DESCRIPTION
go/websocket test failed, run command:
`
cd websocket
go test -v ./...
`

go error:
`=== RUN   TestWSClient
--- PASS: TestWSClient (1.00s)
=== RUN   TestWSPing
10
--- PASS: TestWSPing (2.00s)
=== RUN   TestWSServer
--- FAIL: TestWSServer (1.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6689fc]

goroutine 34 [running]:
testing.tRunner.func1(0xc42016c000)
        /usr/lib/go-1.9/src/testing/testing.go:711 +0x2d2
panic(0x6c11a0, 0x8a6740)
        /usr/lib/go-1.9/src/runtime/panic.go:491 +0x283
github.com/gorilla/websocket.(*Conn).SetPongHandler(0x0, 0x72e318)
        /home/soren/workspace/golang/lib/src/github.com/gorilla/websocket/conn.go:1116 +0x2c
github.com/lsytj0413/go/websocket.TestWSServer(0xc42016c000)
        /home/soren/workspace/golang/src/github.com/lsytj0413/go/websocket/server_test.go:68 +0x1e9
testing.tRunner(0xc42016c000, 0x72e320)
        /usr/lib/go-1.9/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
        /usr/lib/go-1.9/src/testing/testing.go:789 +0x2de
exit status 2
FAIL    github.com/lsytj0413/go/websocket       4.121s`